### PR TITLE
Reset scan results on scan start and remove connected vehicles out of scan results

### DIFF
--- a/src/UserInterface/templates/staff_control.html
+++ b/src/UserInterface/templates/staff_control.html
@@ -165,12 +165,14 @@
     // buttons to search and add cars
     var search_cars = document.getElementById("search_cars");
     var add_car = document.getElementById("add_car");
+    var deviceList = document.getElementById("devices");
 
     search_cars.onclick = function() {
+      // remove old entries
+      deviceList.replaceChildren();
       socket.emit('search_cars');
     }
 
-    var deviceList = document.getElementById("devices");
     socket.on('new_devices', function(devices){
       devices.forEach(function(device) {
         var li = document.createElement('li');

--- a/src/UserInterface/templates/staff_control.html
+++ b/src/UserInterface/templates/staff_control.html
@@ -43,6 +43,9 @@
 <script>
     var socket = io.connect('http://' + document.domain + ':' + location.port);
 
+    // list of devices found by BLE-Scanning
+    var scanResultList = document.getElementById("devices");
+
     socket.on('connect', function(){
         socket.emit('get_uuids');
     });
@@ -68,6 +71,11 @@
 
         // fill table with player and uuids
         for (let player in data) {
+            var search_result = document.getElementById(data[player]);
+            if (scanResultList.contains(search_result)) {
+                scanResultList.remove(search_result);
+            }
+
             var row = document.createElement('tr');
 
             var cell_player = document.createElement('td');
@@ -165,24 +173,24 @@
     // buttons to search and add cars
     var search_cars = document.getElementById("search_cars");
     var add_car = document.getElementById("add_car");
-    var deviceList = document.getElementById("devices");
 
     search_cars.onclick = function() {
       // remove old entries
-      deviceList.replaceChildren();
+      scanResultList.replaceChildren();
       socket.emit('search_cars');
     }
 
     socket.on('new_devices', function(devices){
       devices.forEach(function(device) {
         var li = document.createElement('li');
+        li.setAttribute("id", device);
         li.appendChild(document.createTextNode(device));
         var addButton = document.createElement('button');
         addButton.textContent = 'Add';
         addButton.onclick = function(){ addDevice(device); };
         addButton.className = 'button_small';
         li.appendChild(addButton);
-        deviceList.appendChild(li);
+        scanResultList.appendChild(li);
       });
     });
 


### PR DESCRIPTION
This PR does 2 things:
- It resets the scan results when a new scan is started to avoid getting a very long list (of possibly duplicate results)
- When a connection is established the device is removed from the scan result list

Please test it with multiple cars. Until now it could only be tested locally with a single car