### PR TITLE
Add Virtual cars and map

### DIFF
--- a/src/DataModel/ModelCar.py
+++ b/src/DataModel/ModelCar.py
@@ -2,16 +2,20 @@ from bleak import BleakClient
 
 from DataModel.Vehicle import Vehicle
 from VehicleManagement.AnkiController import AnkiController
-from VehicleManagement.VehicleController import Turns
+from VehicleManagement.VehicleController import Turns, VehicleController
 
 from LocationService.LocationService import LocationService
 from LocationService.Track import FullTrack
 
 
 class ModelCar(Vehicle):
-    def __init__(self, vehicle_id: str, controller: AnkiController, track: FullTrack) -> None:
+    """
+    Base Car implementation that reacts to hacking effects and forwards speed/offset changes to
+    the controller, if appropriate
+    """
+    def __init__(self, vehicle_id: str, controller: VehicleController, track: FullTrack) -> None:
         super().__init__(vehicle_id)
-        self._controller: AnkiController = controller
+        self._controller = controller
         self._location_service: LocationService = LocationService(track)
 
         self.__speed: int = 0
@@ -45,24 +49,11 @@ class ModelCar(Vehicle):
 
     def __del__(self) -> None:
         self._controller.__del__()
+        self._location_service.__del__()
         return
 
     def get_typ_of_controller(self):
         return type(self._controller)
-
-    def initiate_connection(self, uuid: str) -> bool:
-        if self._controller.connect_to_vehicle(BleakClient(uuid), True):
-            self._controller.set_callbacks(self.__receive_location,
-                                           self.__receive_transition,
-                                           self.__receive_offset_update,
-                                           self.__receive_version,
-                                           self.__receive_battery,
-                                           self._on_model_car_not_reachable)
-            self._controller.request_version()
-            self._controller.request_battery()
-            return True
-        else:
-            return False
 
     def set_model_car_not_reachable_callback(self, function_name) -> None:
         self._model_car_not_reachable_callback = function_name
@@ -232,7 +223,7 @@ class ModelCar(Vehicle):
         }
         return driving_info_dic
 
-    def __receive_location(self, value_tuple) -> None:
+    def _receive_location(self, value_tuple) -> None:
         location, piece, offset, speed, clockwise = value_tuple
         self._road_location = location
         self._road_piece = piece
@@ -246,7 +237,7 @@ class ModelCar(Vehicle):
         self._on_driving_data_change()
         return
 
-    def __receive_transition(self, value_tuple) -> None:
+    def _receive_transition(self, value_tuple) -> None:
         piece, piece_prev, offset, direction = value_tuple
         self._road_piece = piece
         self._prev_road_piece = piece_prev
@@ -254,16 +245,16 @@ class ModelCar(Vehicle):
         self._direction = direction
         return
 
-    def __receive_offset_update(self, value_tuple) -> None:
+    def _receive_offset_update(self, value_tuple) -> None:
         offset = value_tuple[0]
         self._offset_from_center = offset
         return
 
-    def __receive_version(self, value_tuple) -> None:
+    def _receive_version(self, value_tuple) -> None:
         self._version = str(value_tuple)
         return
 
-    def __receive_battery(self, value_tuple) -> None:
+    def _receive_battery(self, value_tuple) -> None:
         self._battery = str(value_tuple)
 
         self._on_driving_data_change()

--- a/src/DataModel/ModelCar.py
+++ b/src/DataModel/ModelCar.py
@@ -172,7 +172,7 @@ class ModelCar(Vehicle):
         elif self.__lane_change > 3:
             self.__lane_change = 3
 
-        self._location_service.set_offset(self.__lane_change)
+        self._location_service.set_offset_int(self.__lane_change)
         self._location_service.set_speed_percent(self.__speed)
         self._controller.change_lane_to(self.__lane_change, self.__speed)
         return

--- a/src/DataModel/ModelCar.py
+++ b/src/DataModel/ModelCar.py
@@ -18,7 +18,7 @@ class ModelCar(Vehicle):
     def __init__(self, vehicle_id: str, controller: VehicleController, track: FullTrack, socketio: SocketIO) -> None:
         super().__init__(vehicle_id, socketio)
         self._controller = controller
-        self._location_service: LocationService = LocationService(track, self.__on_locationservice_update)
+        self._location_service: LocationService = LocationService(track, self.__on_location_service_update)
 
         self.__speed: int = 0
         self.__speed_request: int = 0
@@ -262,7 +262,10 @@ class ModelCar(Vehicle):
         self._on_driving_data_change()
         return
 
-    def __on_locationservice_update(self, pos: Position, angle: Angle) -> None:
+    def __on_location_service_update(self, pos: Position, angle: Angle, _: dict):
+        self._send_location_via_socketio(pos, angle)
+
+    def _send_location_via_socketio(self, pos: Position, angle: Angle) -> None:
         data = { 'car': self.vehicle_id, 'position': pos.to_dict(), 'angle': angle.get_deg() }
         self._socketio.emit("car_positions", data)
         return

--- a/src/DataModel/PhysicalCar.py
+++ b/src/DataModel/PhysicalCar.py
@@ -1,13 +1,14 @@
 
 from bleak import BleakClient
+from flask_socketio import SocketIO
 from DataModel.ModelCar import ModelCar
 from LocationService.Track import FullTrack
 from VehicleManagement.AnkiController import AnkiController
 
 
 class PhysicalCar(ModelCar):
-    def __init__(self, vehicle_id: str, controller: AnkiController, track: FullTrack) -> None:
-        super().__init__(vehicle_id, controller, track)
+    def __init__(self, vehicle_id: str, controller: AnkiController, track: FullTrack, socketio: SocketIO) -> None:
+        super().__init__(vehicle_id, controller, track, socketio)
         self._controller: AnkiController = controller
 
     def initiate_connection(self, uuid: str) -> bool:

--- a/src/DataModel/PhysicalCar.py
+++ b/src/DataModel/PhysicalCar.py
@@ -1,0 +1,25 @@
+
+from bleak import BleakClient
+from DataModel.ModelCar import ModelCar
+from LocationService.Track import FullTrack
+from VehicleManagement.AnkiController import AnkiController
+
+
+class PhysicalCar(ModelCar):
+    def __init__(self, vehicle_id: str, controller: AnkiController, track: FullTrack) -> None:
+        super().__init__(vehicle_id, controller, track)
+        self._controller: AnkiController = controller
+
+    def initiate_connection(self, uuid: str) -> bool:
+        if self._controller.connect_to_vehicle(BleakClient(uuid), True):
+            self._controller.set_callbacks(self._receive_location,
+                                           self._receive_transition,
+                                           self._receive_offset_update,
+                                           self._receive_version,
+                                           self._receive_battery,
+                                           self._on_model_car_not_reachable)
+            self._controller.request_version()
+            self._controller.request_battery()
+            return True
+        else:
+            return False

--- a/src/DataModel/Vehicle.py
+++ b/src/DataModel/Vehicle.py
@@ -7,18 +7,22 @@
 # file that should have been included as part of this package.
 #
 
+from flask_socketio import SocketIO
+
 from VehicleManagement.VehicleController import VehicleController
 import abc
 
 
 class Vehicle:
-    def __init__(self, vehicle_id: str, controller: VehicleController = None) -> None:
+    def __init__(self, vehicle_id: str, socketio: SocketIO, controller: VehicleController = None) -> None:
         self.vehicle_id: str = vehicle_id
         self.player: str | None = None
 
         self._controller: VehicleController = controller
         self._active_hacking_scenario: str = "0"
         self._driving_data_callback = None
+
+        self._socketio = socketio
 
         return
 

--- a/src/DataModel/VirtualCar.py
+++ b/src/DataModel/VirtualCar.py
@@ -1,0 +1,9 @@
+from DataModel.ModelCar import ModelCar
+from LocationService.Track import FullTrack
+from VehicleManagement.EmptyController import EmptyController
+
+
+class VirtualCar(ModelCar):
+    def __init__(self, vehicle_id: str, track: FullTrack) -> None:
+        super().__init__(vehicle_id, EmptyController(), track)
+        self._location_service.start()

--- a/src/DataModel/VirtualCar.py
+++ b/src/DataModel/VirtualCar.py
@@ -20,5 +20,11 @@ class VirtualCar(ModelCar):
         else:
             self._speed_actual = int(speed)
 
+        offset: float | None = data.get('offset')
+        if offset is None:
+            print("Error: Location service callback didn't include the offset!")
+        else:
+            self._offset_from_center = offset
+
         self._on_driving_data_change()
         self._send_location_via_socketio(pos, rot)

--- a/src/DataModel/VirtualCar.py
+++ b/src/DataModel/VirtualCar.py
@@ -1,9 +1,11 @@
+from flask_socketio import SocketIO
+
 from DataModel.ModelCar import ModelCar
 from LocationService.Track import FullTrack
 from VehicleManagement.EmptyController import EmptyController
 
 
 class VirtualCar(ModelCar):
-    def __init__(self, vehicle_id: str, track: FullTrack) -> None:
-        super().__init__(vehicle_id, EmptyController(), track)
+    def __init__(self, vehicle_id: str, track: FullTrack, socketio: SocketIO) -> None:
+        super().__init__(vehicle_id, EmptyController(), track, socketio)
         self._location_service.start()

--- a/src/DataModel/VirtualCar.py
+++ b/src/DataModel/VirtualCar.py
@@ -1,11 +1,24 @@
 from flask_socketio import SocketIO
 
 from DataModel.ModelCar import ModelCar
+from LocationService.LocationService import LocationService
 from LocationService.Track import FullTrack
+from LocationService.Trigo import Angle, Position
 from VehicleManagement.EmptyController import EmptyController
 
 
 class VirtualCar(ModelCar):
     def __init__(self, vehicle_id: str, track: FullTrack, socketio: SocketIO) -> None:
         super().__init__(vehicle_id, EmptyController(), track, socketio)
-        self._location_service.start()
+        self._location_service: LocationService = LocationService(track, self.__location_service_update, start_immeaditly=True)
+
+    def __location_service_update(self, pos: Position, rot: Angle, data: dict):
+        speed: float | None = data.get('speed')
+        if speed is None:
+            # TODO: Log via real logger
+            print("Error: Location service callback didn't include the speed!")
+        else:
+            self._speed_actual = int(speed)
+
+        self._on_driving_data_change()
+        self._send_location_via_socketio(pos, rot)

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -264,3 +264,11 @@ class EnvironmentManager:
                     'car': v.get_vehicle_id()
                 })
         return tmp
+
+    def get_car_color_map(self) -> List[List[str]]:
+        colors = ["#F93822", "#DAA03D", "#E69A8D", "#42EADD", "#00203F", "#D6ED17", "#2C5F2D", "#101820"]
+        full_map = []
+        for c in colors:
+            for d in colors:
+                full_map.append([d, c])
+        return full_map

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -7,7 +7,7 @@
 # file that should have been included as part of this package.
 #
 import logging
-from typing import List
+from typing import List, Dict
 from collections import deque
 from flask_socketio import SocketIO
 
@@ -265,10 +265,12 @@ class EnvironmentManager:
                 })
         return tmp
 
-    def get_car_color_map(self) -> List[List[str]]:
+    def get_car_color_map(self) -> Dict[str, List[str]]:
         colors = ["#F93822", "#DAA03D", "#E69A8D", "#42EADD", "#00203F", "#D6ED17", "#2C5F2D", "#101820"]
-        full_map = []
+        full_map: Dict[str, List[str]] = {}
+        num = 1
         for c in colors:
             for d in colors:
-                full_map.append([d, c])
+                full_map.update({f"Virtual Vehicle {num}": [d, c]})
+                num += 1
         return full_map

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -11,7 +11,7 @@ from typing import List
 from collections import deque
 from flask_socketio import SocketIO
 
-from DataModel.ModelCar import ModelCar
+from DataModel.PhysicalCar import PhysicalCar
 from DataModel.Vehicle import Vehicle
 from VehicleManagement.AnkiController import AnkiController
 from VehicleManagement.FleetController import FleetController
@@ -171,7 +171,7 @@ class EnvironmentManager:
         self.logger.debug(f"Adding vehicle with UUID {uuid}")
 
         anki_car_controller = AnkiController()
-        temp_vehicle = ModelCar(uuid, anki_car_controller, self.get_track())
+        temp_vehicle = PhysicalCar(uuid, anki_car_controller, self.get_track())
         temp_vehicle.initiate_connection(uuid)
         # TODO: add a check if connection was successful 
 

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -40,6 +40,8 @@ class EnvironmentManager:
         # number used for naming virtual vehicles
         self._virtual_vehicle_num: int = 1
 
+        self._socketio: SocketIO = socketio
+
     def set_staff_ui(self, staff_ui):
         self.staff_ui = staff_ui
         return
@@ -174,7 +176,7 @@ class EnvironmentManager:
         self.logger.debug(f"Adding vehicle with UUID {uuid}")
 
         anki_car_controller = AnkiController()
-        temp_vehicle = PhysicalCar(uuid, anki_car_controller, self.get_track())
+        temp_vehicle = PhysicalCar(uuid, anki_car_controller, self.get_track(), self._socketio)
         temp_vehicle.initiate_connection(uuid)
         # TODO: add a check if connection was successful 
 
@@ -188,7 +190,7 @@ class EnvironmentManager:
         # used numbers
         name = f"Virtual Vehicle {self._virtual_vehicle_num}"
         self._virtual_vehicle_num += 1
-        vehicle = VirtualCar(name, self.get_track())
+        vehicle = VirtualCar(name, self.get_track(), self._socketio)
         self._active_anki_cars.append(vehicle)
         self._assign_players_to_vehicles()
         self._update_staff_ui()

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -13,6 +13,7 @@ from flask_socketio import SocketIO
 
 from DataModel.PhysicalCar import PhysicalCar
 from DataModel.Vehicle import Vehicle
+from DataModel.VirtualCar import VirtualCar
 from VehicleManagement.AnkiController import AnkiController
 from VehicleManagement.FleetController import FleetController
 from VehicleManagement.VehicleController import VehicleController
@@ -36,6 +37,8 @@ class EnvironmentManager:
 
         # self.find_unpaired_anki_cars()
 
+        # number used for naming virtual vehicles
+        self._virtual_vehicle_num: int = 1
 
     def set_staff_ui(self, staff_ui):
         self.staff_ui = staff_ui
@@ -176,6 +179,17 @@ class EnvironmentManager:
         # TODO: add a check if connection was successful 
 
         self._active_anki_cars.append(temp_vehicle)
+        self._assign_players_to_vehicles()
+        self._update_staff_ui()
+        return
+
+    def add_virtual_vehicle(self):
+        # TODO: Add more better way of determining name numbers to allow reuse of already
+        # used numbers
+        name = f"Virtual Vehicle {self._virtual_vehicle_num}"
+        self._virtual_vehicle_num += 1
+        vehicle = VirtualCar(name, self.get_track())
+        self._active_anki_cars.append(vehicle)
         self._assign_players_to_vehicles()
         self._update_staff_ui()
         return

--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -271,6 +271,8 @@ class EnvironmentManager:
         num = 1
         for c in colors:
             for d in colors:
-                full_map.update({f"Virtual Vehicle {num}": [d, c]})
-                num += 1
+                # disallow same inner and outer color to preserve a contrast
+                if c != d:
+                    full_map.update({f"Virtual Vehicle {num}": [d, c]})
+                    num += 1
         return full_map

--- a/src/LocationService/LocationService.py
+++ b/src/LocationService/LocationService.py
@@ -243,7 +243,7 @@ class LocationService():
             pos, rot = self._run_simulation_step_threadsafe()
             if self._on_update_callback is not None:
                 data: dict = {
-                    'offset': self._actual_offset * self._direction_mult,
+                    'offset': self._actual_offset * self._direction_mult * -1,
                     'speed': self._actual_speed,
                     'going_clockwise': self._direction_mult == 1,
                     'uturn_in_progress': self._uturn_override is not None

--- a/src/LocationService/Track.py
+++ b/src/LocationService/Track.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Tuple
+from typing import List, Tuple
 
 from LocationService.Trigo import Position, Angle
 
@@ -68,6 +68,13 @@ class TrackPiece(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def to_dict(self) -> dict:
+        """
+        Get the piece represented as dict
+        """
+        raise NotImplementedError
+
 class TrackEntry():
     def __init__(self, track_piece, offset):
         self.track_piece: TrackPiece = track_piece
@@ -123,3 +130,15 @@ class FullTrack():
 
     def get_len(self):
         return len(self.track_entries)
+
+    def get_as_list(self) -> List[dict]:
+        l: list[dict] = []
+        for entry in self.track_entries:
+            piece = entry.get_piece()
+            offset = entry.get_global_offset()
+            l.append({
+                'offset': offset.to_dict(),
+                'piece': piece.to_dict()
+            })
+
+        return l

--- a/src/LocationService/TrackPieces.py
+++ b/src/LocationService/TrackPieces.py
@@ -58,6 +58,39 @@ class StraightPiece(TrackPiece):
     def get_equivalent_progress_for_offset(self, old_offset: float, new_offset: float, old_progress: float) -> float:
         return old_progress
 
+    def to_dict(self) -> dict:
+        line_1_start = Position(-self._diameter / 2, -self._length / 2)
+        line_1_end = Position(-self._diameter / 2, self._length / 2)
+        line_1_start.rotate_around_0_0(self._rotation)
+        line_1_end.rotate_around_0_0(self._rotation)
+
+        line_2_start = Position(self._diameter / 2, -self._length / 2)
+        line_2_end = Position(self._diameter / 2, self._length / 2)
+        line_2_start.rotate_around_0_0(self._rotation)
+        line_2_end.rotate_around_0_0(self._rotation)
+
+        return {
+
+            'type': 'straight_piece',
+            'rotation': str(self._rotation),
+            'line_1_start': {
+                'x': line_1_start.get_x(),
+                'y': line_1_start.get_y()
+            },
+            'line_1_end': {
+                'x': line_1_end.get_x(),
+                'y': line_1_end.get_y()
+            },
+            'line_2_start': {
+                'x': line_2_start.get_x(),
+                'y': line_2_start.get_y()
+            },
+            'line_2_end': {
+                'x': line_2_end.get_x(),
+                'y': line_2_end.get_y()
+            }
+        }
+
 class CurvedPiece(TrackPiece):
     def __init__(self, square_size, diameter: int, rot: int, mirror: bool):
         super().__init__(rot)
@@ -126,6 +159,23 @@ class CurvedPiece(TrackPiece):
     def get_equivalent_progress_for_offset(self, old_offset: float, new_offset: float, old_progress: float) -> float:
         percent = old_progress / self.get_length(old_offset)
         return percent * self.get_length(new_offset)
+
+    def to_dict(self) -> dict:
+        start_angle: int = int(self._rotation.get_deg())
+        point: Position = Position(-self._size / 2, -self._size / 2)
+        point.rotate_around_0_0(self._rotation)
+        radius_1: float = self._radius - self._diameter / 2
+        radius_2: float = self._radius + self._diameter / 2
+        return {
+            'type': 'curved_piece',
+            'start_angle': start_angle,
+            'radius_1': radius_1,
+            'radius_2': radius_2,
+            'point': {
+                'x': point.get_x(),
+                'y': point.get_y()
+            }
+        }
 
 
 class TrackBuilder():

--- a/src/LocationService/TrackPieces.py
+++ b/src/LocationService/TrackPieces.py
@@ -162,7 +162,11 @@ class CurvedPiece(TrackPiece):
 
     def to_dict(self) -> dict:
         start_angle: int = int(self._rotation.get_deg())
+        if self._is_mirrored:
+            start_angle = (start_angle + 180) % 360
         point: Position = Position(-self._size / 2, -self._size / 2)
+        if self._is_mirrored:
+            point.rotate_around_0_0(Angle(180))
         point.rotate_around_0_0(self._rotation)
         radius_1: float = self._radius - self._diameter / 2
         radius_2: float = self._radius + self._diameter / 2

--- a/src/LocationService/Trigo.py
+++ b/src/LocationService/Trigo.py
@@ -1,5 +1,5 @@
 import math
-from typing import Tuple
+from typing import Dict, Tuple
 
 class Angle():
     """

--- a/src/LocationService/Trigo.py
+++ b/src/LocationService/Trigo.py
@@ -100,3 +100,6 @@ class Position():
 
     def clone(self):
         return Position(self._x, self._y)
+
+    def to_dict(self) -> dict:
+        return { 'x': self._x, 'y': self._y }

--- a/src/UserInterface/CarMap.py
+++ b/src/UserInterface/CarMap.py
@@ -7,8 +7,8 @@ class CarMap:
         self._environment_manager = environment_manager
 
         def home_car_map():
-            # TODO: Add track into template and render it
-            return render_template("car_map.html")
+            track = environment_manager.get_track().get_as_list()
+            return render_template("car_map.html", track=track)
         self.carMap_blueprint.add_url_rule("", "home_car_map", view_func=home_car_map)
 
     def get_blueprint(self) -> Blueprint:

--- a/src/UserInterface/CarMap.py
+++ b/src/UserInterface/CarMap.py
@@ -1,0 +1,15 @@
+from flask import Blueprint, render_template
+from EnvironmentManagement.EnvironmentManager import EnvironmentManager
+
+class CarMap:
+    def __init__(self, environment_manager: EnvironmentManager):
+        self.carMap_blueprint: Blueprint = Blueprint(name='carMap_bp', import_name='carMap_bp')
+        self._environment_manager = environment_manager
+
+        def home_car_map():
+            # TODO: Add track into template and render it
+            return render_template("car_map.html")
+        self.carMap_blueprint.add_url_rule("", "home_car_map", view_func=home_car_map)
+
+    def get_blueprint(self) -> Blueprint:
+        return self.carMap_blueprint

--- a/src/UserInterface/CarMap.py
+++ b/src/UserInterface/CarMap.py
@@ -8,7 +8,7 @@ class CarMap:
 
         def home_car_map():
             track = environment_manager.get_track().get_as_list()
-            return render_template("car_map.html", track=track)
+            return render_template("car_map.html", track=track, color_map=environment_manager.get_car_color_map())
         self.carMap_blueprint.add_url_rule("", "home_car_map", view_func=home_car_map)
 
     def get_blueprint(self) -> Blueprint:

--- a/src/UserInterface/StaffUI.py
+++ b/src/UserInterface/StaffUI.py
@@ -56,7 +56,7 @@ class StaffUI:
                 self.logger.warning("Not authenticated")
                 return login_redirect()
             selected_option = request.form.get('option')
-            pattern = r"scenarioID_(\d+)-UUID_([A-Fa-f0-9:]+)>"
+            pattern = r"scenarioID_(\d+)-UUID_([A-Fa-f0-9:]+|Virtual Vehicle [0-9]+)>"
             match = re.search(pattern, selected_option)
 
             scenario_id = match.group(1)
@@ -125,6 +125,15 @@ class StaffUI:
             # TODO: exception if device is no longer available
             self.cybersecurity_mng._update_active_hacking_scenarios(device, '0')
             return
+
+        @self.socketio.on('add_virtual_vehicle')
+        def handle_add_virtual_vehicle() -> None:
+            if not is_authenticated():
+                self.logger.warning("Not authenticated")
+                return
+            name = environment_mng.add_virtual_vehicle()
+            self.socketio.emit('device_added', name)
+            self.cybersecurity_mng._update_active_hacking_scenarios(name, '0')
 
         @self.socketio.on('delete_player')
         def handle_delete_player(player: str) -> None:

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -51,9 +51,7 @@
                     var x = d.position.x;
                     var y = d.position.y;
                     var angle = d.angle;
-                    const num = getVehicleNum(name);
-                    const colors = colorCrossmap[num];
-                    // TODO: Implement drawing images too
+                    const colors = colorCrossmap[name];
                     drawCarBox(x, y, angle, colors[0], colors[1]);
                 }
             });
@@ -148,11 +146,6 @@
             function resizeCanvas() {
                 canvas.width = window.innerWidth;
                 canvas.height = window.innerHeight;
-            }
-
-            const vehicleNumRe = /Virtual Vehicle (\d+)/;
-            function getVehicleNum(name) {
-                return name.match(vehicleNumRe)[1];
             }
         </script>
     </body>

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -33,14 +33,7 @@
             const car_width = 30;
             const car_outline = 4;
 
-            const colorMap = new Map();
-            const colors = ["#F93822", "#DAA03D", "#E69A8D", "#42EADD", "#00203F", "#D6ED17", "#2C5F2D", "#101820"];
-            const colorCrossmap = [];
-            for (const c of colors) {
-                for (const d of colors) {
-                    colorCrossmap.push([d, c]);
-                }
-            }
+            const colorCrossmap = {{ color_map | tojson }};
 
             resizeCanvas();
             resetCanvas();

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Car map</title>
+
+    <!-- general style sheet -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='general.css')}}"/> <!-- to include stylesheet when running webinterface with flask -->
+	  <link rel="stylesheet" href="../static/general.css"/> <!-- link to stylesheet for development for working preview -->
+
+    <!-- Include socket.io library -->
+    <script src="{{ url_for('static', filename='external_resources/socketio/4.7.5/socket.io.js')}}" ></script>
+</head>
+
+<body>
+    <canvas id="car_canvas"></canvas>
+
+        <script type="text/javascript" charset="utf-8">
+            var socket = io.connect('http://' + document.domain + ':' + location.port);
+
+            var canvas = document.getElementById("car_canvas");
+            var ctx = canvas.getContext("2d");
+            const dataMap = new Map();
+
+            const colorMap = new Map();
+            colorMap.set("Virtual Vehicle 1", "#ff0000");
+            colorMap.set("Virtual Vehicle 2", "#ff8000");
+            colorMap.set("Virtual Vehicle 3", "#ffff00");
+            colorMap.set("Virtual Vehicle 4", "#00ff00");
+            colorMap.set("Virtual Vehicle 5", "#0000ff");
+            colorMap.set("Virtual Vehicle 6", "#ff00ff");
+
+            socket.on('car_positions', function(data){
+                var carName = data.car;
+                dataMap.set(carName, data);
+                resizeCanvas();
+                resetCanvas();
+                drawTrack();
+                for (const car of dataMap) {
+                    const name = car[0];
+                    const d = car[1];
+                    var x = d.position.x;
+                    var y = d.position.y;
+                    var angle = d.angle;
+                    drawCar(x, y, angle, colorMap.get(name));
+                }
+            });
+
+            function drawCar(x, y, angle, color) {
+                // TODO: Draw as rectangle with rotation
+                ctx.beginPath();
+                // x, y, radius, startAngle, endAngle
+                ctx.arc(x, y, 10, 0, 2 * Math.PI);
+                ctx.strokeStyle = color;
+                ctx.fillStyle = color;
+                ctx.fill();
+                ctx.closePath();
+
+                ctx.moveTo(x, y);
+                ctx.lineWidth = 10;
+                theta = Math.PI * (angle - 90) / 180.0;
+                lineLength = 75;
+                ctx.lineTo(x + lineLength * Math.cos(theta), y + lineLength * Math.sin(theta));
+
+                ctx.stroke();
+            }
+
+            function drawTrack() {
+                // TODO: Implement; track could be given via template
+            }
+
+            function resetCanvas() { 
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
+            }
+
+            function resizeCanvas() {
+                canvas.width = window.innerWidth;
+                canvas.height = window.innerHeight;
+            }
+        </script>
+    </body>
+</html>

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -18,6 +18,9 @@
         <script type="text/javascript" charset="utf-8">
             var socket = io.connect('http://' + document.domain + ':' + location.port);
 
+            // TODO: Calculate scale based on track so it fits well on the page
+            const scale = 0.5;
+
             var canvas = document.getElementById("car_canvas");
             var ctx = canvas.getContext("2d");
             const dataMap = new Map();
@@ -58,17 +61,17 @@
                 // TODO: Draw as rectangle with rotation
                 ctx.beginPath();
                 // x, y, radius, startAngle, endAngle
-                ctx.arc(x, y, 10, 0, 2 * Math.PI);
+                ctx.arc(x * scale, y * scale, 10 * scale, 0, 2 * Math.PI);
                 ctx.strokeStyle = color;
                 ctx.fillStyle = color;
                 ctx.fill();
                 ctx.closePath();
 
-                ctx.moveTo(x, y);
-                ctx.lineWidth = 10;
+                ctx.moveTo(x * scale, y * scale);
+                ctx.lineWidth = 10 * scale;
                 theta = Math.PI * (angle - 90) / 180.0;
                 lineLength = 75;
-                ctx.lineTo(x + lineLength * Math.cos(theta), y + lineLength * Math.sin(theta));
+                ctx.lineTo((x + lineLength * Math.cos(theta)) * scale, (y + lineLength * Math.sin(theta)) * scale);
 
                 ctx.stroke();
             }
@@ -85,12 +88,12 @@
             }
 
             function drawStraightTrackLine(x1, y1, x2, y2) {
-                ctx.lineWidth = track_width;
+                ctx.lineWidth = track_width * scale;
                 ctx.strokeStyle = track_color;
 
                 ctx.beginPath();
-                ctx.moveTo(x1, y1);
-                ctx.lineTo(x2, y2);
+                ctx.moveTo(x1 * scale, y1 * scale);
+                ctx.lineTo(x2 * scale, y2 * scale);
                 ctx.stroke();
             }
 
@@ -98,12 +101,12 @@
                 start_rad = (start_deg - 90) * Math.PI / 180;
                 end_rad = start_rad + 0.5 * Math.PI;
 
-                ctx.lineWidth = track_width;
-                ctx.strokeStyle = track_color;
+                ctx.lineWidth = track_width * scale;
+                ctx.strokeStyle = track_color * scale;
 
                 ctx.beginPath();
                 // x, y, radius, startAngle, endAngle
-                ctx.arc(x, y, radius, start_rad, end_rad);
+                ctx.arc(x * scale, y * scale, radius * scale, start_rad, end_rad);
                 ctx.stroke();
             }
 

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -29,13 +29,18 @@
             const track_color = "#000000";
             const track_width = 5;
 
+            const car_length = 82;
+            const car_width = 30;
+            const car_outline = 4;
+
             const colorMap = new Map();
-            colorMap.set("Virtual Vehicle 1", "#ff0000");
-            colorMap.set("Virtual Vehicle 2", "#ff8000");
-            colorMap.set("Virtual Vehicle 3", "#ffff00");
-            colorMap.set("Virtual Vehicle 4", "#00ff00");
-            colorMap.set("Virtual Vehicle 5", "#0000ff");
-            colorMap.set("Virtual Vehicle 6", "#ff00ff");
+            const colors = ["#F93822", "#DAA03D", "#E69A8D", "#42EADD", "#00203F", "#D6ED17", "#2C5F2D", "#101820"];
+            const colorCrossmap = [];
+            for (const c of colors) {
+                for (const d of colors) {
+                    colorCrossmap.push([d, c]);
+                }
+            }
 
             resizeCanvas();
             resetCanvas();
@@ -53,27 +58,34 @@
                     var x = d.position.x;
                     var y = d.position.y;
                     var angle = d.angle;
-                    drawCar(x, y, angle, colorMap.get(name));
+                    const num = getVehicleNum(name);
+                    const colors = colorCrossmap[num];
+                    // TODO: Draw preferably as image, if enough images are there
+                    drawCarBox(x, y, angle, colors[0], colors[1]);
                 }
             });
 
-            function drawCar(x, y, angle, color) {
-                // TODO: Draw as rectangle with rotation
+            function drawCarBox(x, y, angle, colorInner, colorOuter) {
+                x *= scale;
+                y *= scale;
+                ctx.save();
+
+                rotationRadians = Math.PI * (angle - 90) / 180.0;
+                // do rotation for rect
+                ctx.translate(x, y);
+                ctx.rotate(rotationRadians);
+                ctx.translate(-x, -y);
                 ctx.beginPath();
-                // x, y, radius, startAngle, endAngle
-                ctx.arc(x * scale, y * scale, 10 * scale, 0, 2 * Math.PI);
-                ctx.strokeStyle = color;
-                ctx.fillStyle = color;
+                ctx.strokeStyle = colorOuter;
+                ctx.fillStyle = colorInner;
+                ctx.lineWidth = car_outline * scale;
+                ctx.rect(x - car_length * scale / 2, y - car_width * scale / 2, car_length * scale, car_width * scale);
                 ctx.fill();
-                ctx.closePath();
-
-                ctx.moveTo(x * scale, y * scale);
-                ctx.lineWidth = 10 * scale;
-                theta = Math.PI * (angle - 90) / 180.0;
-                lineLength = 75;
-                ctx.lineTo((x + lineLength * Math.cos(theta)) * scale, (y + lineLength * Math.sin(theta)) * scale);
-
                 ctx.stroke();
+                ctx.closePath();
+                ctx.rotate(-Math.PI / 2);
+
+                ctx.restore();
             }
 
             function drawTrack() {
@@ -143,6 +155,11 @@
             function resizeCanvas() {
                 canvas.width = window.innerWidth;
                 canvas.height = window.innerHeight;
+            }
+
+            const vehicleNumRe = /Virtual Vehicle (\d+)/;
+            function getVehicleNum(name) {
+                return name.match(vehicleNumRe)[1];
             }
         </script>
     </body>

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -70,7 +70,7 @@
             }
 
             function resetCanvas() { 
-                ctx.clearRect(0, 0, canvas.width, canvas.height);
+                ctx.reset();
             }
 
             function resizeCanvas() {

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -60,7 +60,7 @@
                     var angle = d.angle;
                     const num = getVehicleNum(name);
                     const colors = colorCrossmap[num];
-                    // TODO: Draw preferably as image, if enough images are there
+                    // TODO: Implement drawing images too
                     drawCarBox(x, y, angle, colors[0], colors[1]);
                 }
             });

--- a/src/UserInterface/templates/car_map.html
+++ b/src/UserInterface/templates/car_map.html
@@ -22,6 +22,10 @@
             var ctx = canvas.getContext("2d");
             const dataMap = new Map();
 
+            var track = {{track | tojson}};
+            const track_color = "#000000";
+            const track_width = 5;
+
             const colorMap = new Map();
             colorMap.set("Virtual Vehicle 1", "#ff0000");
             colorMap.set("Virtual Vehicle 2", "#ff8000");
@@ -29,6 +33,10 @@
             colorMap.set("Virtual Vehicle 4", "#00ff00");
             colorMap.set("Virtual Vehicle 5", "#0000ff");
             colorMap.set("Virtual Vehicle 6", "#ff00ff");
+
+            resizeCanvas();
+            resetCanvas();
+            drawTrack();
 
             socket.on('car_positions', function(data){
                 var carName = data.car;
@@ -66,7 +74,63 @@
             }
 
             function drawTrack() {
-                // TODO: Implement; track could be given via template
+                for (const piece of track) {
+                    piece_type = piece.piece.type;
+                    if (piece_type == "straight_piece") {
+                        drawStraightPiece(piece);
+                    } else if (piece_type == "curved_piece") {
+                        drawCurvedPiece(piece);
+                    }
+                }
+            }
+
+            function drawStraightTrackLine(x1, y1, x2, y2) {
+                ctx.lineWidth = track_width;
+                ctx.strokeStyle = track_color;
+
+                ctx.beginPath();
+                ctx.moveTo(x1, y1);
+                ctx.lineTo(x2, y2);
+                ctx.stroke();
+            }
+
+            function drawCuvedTrackLine(x, y, radius, start_deg) {
+                start_rad = (start_deg - 90) * Math.PI / 180;
+                end_rad = start_rad + 0.5 * Math.PI;
+
+                ctx.lineWidth = track_width;
+                ctx.strokeStyle = track_color;
+
+                ctx.beginPath();
+                // x, y, radius, startAngle, endAngle
+                ctx.arc(x, y, radius, start_rad, end_rad);
+                ctx.stroke();
+            }
+
+            function drawStraightPiece(piece) {
+                offset_x = piece.offset.x;
+                offset_y = piece.offset.y;
+                line_1_start_x = offset_x + piece.piece.line_1_start.x;
+                line_1_start_y = offset_y + piece.piece.line_1_start.y;
+                line_1_end_x = offset_x + piece.piece.line_1_end.x;
+                line_1_end_y = offset_y + piece.piece.line_1_end.y;
+
+                line_2_start_x = offset_x + piece.piece.line_2_start.x;
+                line_2_start_y = offset_y + piece.piece.line_2_start.y;
+                line_2_end_x = offset_x + piece.piece.line_2_end.x;
+                line_2_end_y = offset_y + piece.piece.line_2_end.y;
+                drawStraightTrackLine(line_1_start_x, line_1_start_y, line_1_end_x, line_1_end_y);
+                drawStraightTrackLine(line_2_start_x, line_2_start_y, line_2_end_x, line_2_end_y);
+            }
+
+            function drawCurvedPiece(piece) {
+                start_point_x = piece.offset.x + piece.piece.point.x;
+                start_point_y = piece.offset.y + piece.piece.point.y;
+                radius_1 = piece.piece.radius_1;
+                radius_2 = piece.piece.radius_2;
+                start_angle = piece.piece.start_angle + 90;
+                drawCuvedTrackLine(start_point_x, start_point_y, radius_1, start_angle);
+                drawCuvedTrackLine(start_point_x, start_point_y, radius_2, start_angle);
             }
 
             function resetCanvas() { 

--- a/src/UserInterface/templates/staff_control.html
+++ b/src/UserInterface/templates/staff_control.html
@@ -33,9 +33,12 @@
             <h2>List of Players/Cars:</h2>
             <div class="flexbox-item flexbox-activeCars" id="table-container"></div>
 
-            <h3>Add cars... </h3>
+            <h3>Add physical cars... </h3>
             <button id="search_cars"> Search... </button>
             <ul class="flexbox-item flexbox-activeCars" id="devices"></ul>
+
+            <h3>Add virtual car</h3>
+            <button id="add_virtual_car"> Add</button>
         </div>
 
     </div>
@@ -217,10 +220,16 @@
     // buttons to search and add cars
     var search_cars = document.getElementById("search_cars");
     var add_car = document.getElementById("add_car");
+    var add_virtual_car = document.getElementById("add_virtual_car");
 
     search_cars.onclick = function() {
       socket.emit('search_cars');
     }
+
+    add_virtual_car.onclick = function() {
+      socket.emit('add_virtual_vehicle');
+    }
+
 
     var deviceList = document.getElementById("devices");
     socket.on('new_devices', function(devices){

--- a/src/VehicleManagement/EmptyController.py
+++ b/src/VehicleManagement/EmptyController.py
@@ -1,0 +1,23 @@
+from VehicleManagement.VehicleController import TurnTrigger, Turns, VehicleController
+
+
+class EmptyController(VehicleController):
+    """
+    Controller that does absolutely nothing on every function call. Used for
+    virtual vehicles that don't need to send their data to any physical car
+    """
+    def __init__(self) -> None:
+        return
+
+    def __del__(self) -> None:
+        return
+
+    def change_speed_to(self, velocity: int, acceleration: int = 1000, respect_speed_limit: bool = True) -> bool:
+        return True
+
+    def change_lane_to(self, change_direction: int, velocity: int, acceleration: int = 1000) -> bool:
+        return True
+
+    def do_turn_with(self, direction: Turns,
+                     turntrigger: TurnTrigger = TurnTrigger.VEHICLE_TURN_TRIGGER_IMMEDIATE) -> bool:
+        return True

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from EnvironmentManagement.EnvironmentManager import EnvironmentManager
 from CyberSecurityManager.CyberSecurityManager import CyberSecurityManager
 from UserInterface.DriverUI import DriverUI
 from UserInterface.StaffUI import StaffUI
+from UserInterface.CarMap import CarMap
 from flask import Flask
 from flask_socketio import SocketIO
 
@@ -37,9 +38,12 @@ def main(admin_password: str):
     driver_ui_blueprint = driver_ui.get_blueprint()
     staff_ui = StaffUI(cybersecurity_mng=cybersecurity_mng, socketio=socketio, environment_mng=environment_mng, password=admin_password)
     staff_ui_blueprint = staff_ui.get_blueprint()
+    car_map = CarMap(environment_manager=environment_mng)
+    car_map_blueprint = car_map.get_blueprint()
 
     app.register_blueprint(driver_ui_blueprint, url_prefix='/driver')
     app.register_blueprint(staff_ui_blueprint, url_prefix='/staff')
+    app.register_blueprint(car_map_blueprint, url_prefix='/car_map')
     socketio.run(app, debug=True, host='0.0.0.0', allow_unsafe_werkzeug=True)
 
 

--- a/test/IntegrationTest/DataModel/ModelCar_IntegrationTest.py
+++ b/test/IntegrationTest/DataModel/ModelCar_IntegrationTest.py
@@ -1,10 +1,19 @@
 from unittest import TestCase
 
-from DataModel.ModelCar import ModelCar
+from DataModel.PhysicalCar import PhysicalCar
 from VehicleManagement.AnkiController import AnkiController
 from VehicleManagement.FleetController import FleetController
 
+from LocationService.TrackPieces import TrackBuilder, FullTrack
+from LocationService.Track import TrackPieceType
+
 dummy_vehicleID = "123456789"
+
+def get_dummy_track() -> FullTrack:
+        track: FullTrack = TrackBuilder()\
+            .append(TrackPieceType.STRAIGHT_WE)\
+            .build()
+        return track
 
 
 def dummy_callback(vehicle_id: str, player: str, err_msg: str):
@@ -15,7 +24,7 @@ class ModelCaIntegrationTest(TestCase):
     def setUp(self) -> None:
         self.dummy_uuid = FleetController().scan_for_anki_cars()[0]
         self.anki_controller: AnkiController = AnkiController()
-        self.mut: ModelCar = ModelCar(dummy_vehicleID, self.anki_controller)
+        self.mut: PhysicalCar = PhysicalCar(dummy_vehicleID, self.anki_controller, get_dummy_track())
         self.mut.set_model_car_not_reachable_callback(dummy_callback)
 
     def tearDown(self) -> None:

--- a/test/UnitTest/DataModel/ModelCar_Test.py
+++ b/test/UnitTest/DataModel/ModelCar_Test.py
@@ -2,8 +2,17 @@ from unittest import TestCase
 from unittest.mock import Mock
 from TestingTools import generate_mac_address
 
-from DataModel.ModelCar import ModelCar
+from DataModel.PhysicalCar import PhysicalCar
 from VehicleManagement.AnkiController import AnkiController
+
+from LocationService.TrackPieces import TrackBuilder, FullTrack
+from LocationService.Track import TrackPieceType
+
+def get_dummy_track() -> FullTrack:
+        track: FullTrack = TrackBuilder()\
+            .append(TrackPieceType.STRAIGHT_WE)\
+            .build()
+        return track
 
 
 class ModelCarTest(TestCase):
@@ -22,7 +31,7 @@ class ModelCarTest(TestCase):
         # Arrange
 
         # Act
-        self.mut = ModelCar(self.dummy_uuid, self.anki_controller_mock)
+        self.mut = PhysicalCar(self.dummy_uuid, self.anki_controller_mock, get_dummy_track())
 
         # Assert
         assert self.mut.vehicle_id == self.dummy_uuid
@@ -30,7 +39,7 @@ class ModelCarTest(TestCase):
 
     def test_calculate_speed(self):
         # Arrange
-        self.mut: ModelCar = ModelCar(self.dummy_uuid, self.anki_controller_mock)
+        self.mut: PhysicalCar = PhysicalCar(self.dummy_uuid, self.anki_controller_mock, get_dummy_track())
 
         # Act/Assert
         self.mut.speed_factor = 0.5

--- a/test/UnitTest/LocationService/Simulation.py
+++ b/test/UnitTest/LocationService/Simulation.py
@@ -5,7 +5,7 @@ from LocationService.LocationService import LocationService
 from LocationService.Track import TrackPieceType, TrackPiece
 from LocationService.Trigo import Position, Angle
 
-def do_nothing(pos: Position, angle: Angle):
+def do_nothing(pos: Position, angle: Angle, data: dict):
     pass
 
 # Constants

--- a/test/UnitTest/LocationService/Simulation.py
+++ b/test/UnitTest/LocationService/Simulation.py
@@ -3,7 +3,10 @@ import pytest
 from LocationService.TrackPieces import TrackBuilder, FullTrack
 from LocationService.LocationService import LocationService
 from LocationService.Track import TrackPieceType, TrackPiece
-from LocationService.Trigo import Position
+from LocationService.Trigo import Position, Angle
+
+def do_nothing(pos: Position, angle: Angle):
+    pass
 
 # Constants
 def STRAIGHT_PIECE_LENGTH():
@@ -39,7 +42,7 @@ def test_track_transistion():
     """
     Test the transition from one track piece onto the next one
     """
-    location_service = LocationService(get_two_straight_pieces(), simulation_ticks_per_second=1, start_immeaditly=False)
+    location_service = LocationService(get_two_straight_pieces(), do_nothing, simulation_ticks_per_second=1, start_immeaditly=False)
     location_service._set_speed_mm(1, acceleration=1)
     for i in range(0, STRAIGHT_PIECE_LENGTH()):
         location_service._run_simulation_step_threadsafe()
@@ -57,7 +60,7 @@ def test_acceleration(speed, acceleration):
     """
     Test that the vehicle accelerates correctly
     """
-    location_service = LocationService(get_two_straight_pieces(), simulation_ticks_per_second=1, start_immeaditly=False)
+    location_service = LocationService(get_two_straight_pieces(), do_nothing, simulation_ticks_per_second=1, start_immeaditly=False)
     location_service._set_speed_mm(speed, acceleration=acceleration)
     sum = 0
     for _ in range(0, int(speed / acceleration)):
@@ -113,7 +116,7 @@ def test_multiple_transitions(speed: float, offset: float):
     Test the transitions against jumping at a full track
     """
     track = get_loop_track()
-    location_service = LocationService(track, simulation_ticks_per_second=1, start_immeaditly=False)
+    location_service = LocationService(track, do_nothing, simulation_ticks_per_second=1, start_immeaditly=False)
     location_service._set_speed_mm(speed, acceleration=1)
     location_service._set_offset_mm(offset)
     # progress a bit on the first piece
@@ -139,7 +142,7 @@ def test_offset(offset: float):
     """
     Test the offset changing on the track itself for different values
     """
-    location_service = LocationService(get_two_straight_pieces(), simulation_ticks_per_second=1, start_immeaditly=False)
+    location_service = LocationService(get_two_straight_pieces(), do_nothing, simulation_ticks_per_second=1, start_immeaditly=False)
     location_service._set_speed_mm(1, acceleration=1)
     old_pos, _ = location_service._run_simulation_step_threadsafe()
     location_service._set_offset_mm(offset)
@@ -155,7 +158,7 @@ def test_position_rotation():
     Test the returned rotation value, where the car is pointing for plausibility
     """
     track = get_loop_track()
-    location_service = LocationService(track, simulation_ticks_per_second=1, start_immeaditly=False)
+    location_service = LocationService(track, do_nothing, simulation_ticks_per_second=1, start_immeaditly=False)
     location_service._set_speed_mm(1, acceleration=1)
     location_service._run_simulation_step_threadsafe()
     # for the 1st piece it should always be 90° (pointing right)


### PR DESCRIPTION
This commit adds the following:
- Virtual cars which gets their offset from the Simulation of the LocationService
- A Car Map that visualizes the position of virtual cars on a virtual track

The rendering of images wasn't added since their implementation was rather hacky and should be done properly. This PR includes 2 changes since the Car Map is a good way of seeing whether the Virtual Vehicles work. For "testing" I used the following track (replace appropriately in the EnvironementManager):
```python
track: FullTrack = TrackBuilder()\
    .append(TrackPieceType.CURVE_WS)\
    .append(TrackPieceType.STRAIGHT_NS)\
    .append(TrackPieceType.CURVE_NE)\
    .append(TrackPieceType.CURVE_WN)\
    .append(TrackPieceType.STRAIGHT_SN)\
    .append(TrackPieceType.CURVE_SE)\
    .append(TrackPieceType.CURVE_WS)\
    .append(TrackPieceType.STRAIGHT_NS)\
    .append(TrackPieceType.CURVE_NE)\
    .append(TrackPieceType.CURVE_WN)\
    .append(TrackPieceType.STRAIGHT_SN)\
    .append(TrackPieceType.CURVE_SE)\
    .append(TrackPieceType.STRAIGHT_WE)\
    .append(TrackPieceType.CURVE_WS)\
    .append(TrackPieceType.STRAIGHT_NS)\
    .append(TrackPieceType.STRAIGHT_NS)\
    .append(TrackPieceType.CURVE_NW)\
    .append(TrackPieceType.STRAIGHT_EW)\
    .append(TrackPieceType.STRAIGHT_EW)\
    .append(TrackPieceType.STRAIGHT_EW)\
    .append(TrackPieceType.STRAIGHT_EW)\
    .append(TrackPieceType.STRAIGHT_EW)\
    .append(TrackPieceType.CURVE_EN)\
    .append(TrackPieceType.STRAIGHT_SN)\
    .append(TrackPieceType.STRAIGHT_SN)\
    .append(TrackPieceType.CURVE_SE)\
    .build()
```