### PR TITLE
Bugfix: Sometimes physical cars get added 2 times

### DIFF
--- a/src/EnvironmentManagement/EnvironmentManager.py
+++ b/src/EnvironmentManagement/EnvironmentManager.py
@@ -564,6 +564,10 @@ class EnvironmentManager:
         return
 
     def _add_to_active_vehicle_list(self, new_vehicle: Vehicle) -> None:
+        vehicle_already_exists = self.get_vehicle_by_vehicle_id(new_vehicle.get_vehicle_id()) is not None
+        if vehicle_already_exists:
+            self.logger.warning("Tried to add a vehicle that already exists. Ignoring the request")
+            return
         self._active_anki_cars.append(new_vehicle)
         self._assign_players_to_vehicles()
         self.update_staff_ui()

--- a/test/UnitTest/EnvironmentManagement/EnvironmentManager_Test.py
+++ b/test/UnitTest/EnvironmentManagement/EnvironmentManager_Test.py
@@ -453,3 +453,27 @@ async def test_vehicle_removal_on_non_reachable(car_uuid: str = 'DF:8B:DC:02:2C:
             behavior_controller.request_lane_change_for(car_uuid, 'right')
         await asyncio.sleep(0.5)
     assert False
+
+
+def test_vehicle_cant_be_added_twice(get_two_dummy_vehicles):
+    """
+    This tests that vehicles with the same ID can only be added once
+    """
+    fleet_mock = MagicMock(spec=FleetController)
+    config_mock = MagicMock(spec=ConfigurationHandler)
+    env_manager = EnvironmentManager(fleet_mock, configuration_handler=config_mock)
+    vehicle1, vehicle2 = get_two_dummy_vehicles
+    new_vehicle_1 = Vehicle(vehicle1.get_vehicle_id())
+    new_vehicle_2 = Vehicle(vehicle2.get_vehicle_id())
+
+    env_manager._add_to_active_vehicle_list(vehicle1)
+    env_manager._add_to_active_vehicle_list(vehicle1)
+    env_manager._add_to_active_vehicle_list(new_vehicle_1)
+    env_manager._add_to_active_vehicle_list(new_vehicle_1)
+    assert len(env_manager._active_anki_cars) == 1
+
+    env_manager._add_to_active_vehicle_list(vehicle2)
+    env_manager._add_to_active_vehicle_list(vehicle2)
+    env_manager._add_to_active_vehicle_list(new_vehicle_2)
+    env_manager._add_to_active_vehicle_list(new_vehicle_2)
+    assert len(env_manager._active_anki_cars) == 2


### PR DESCRIPTION
This is done by preventing the same vehicle ID to exist multiple times in the active vehicle list