### PR TITLE
Improvement: Cars arent found while scanning sometimes

### DIFF
--- a/src/VehicleManagement/FleetController.py
+++ b/src/VehicleManagement/FleetController.py
@@ -38,7 +38,8 @@ class FleetController:
         ble_devices = await BleakScanner.discover(return_adv=True)
         _active_devices = []
         if only_ready:
-            _all_devices = [d for d in ble_devices.values() if d[0].name is not None and "Drive" in d[0].name]
+            _all_devices = [d for d in ble_devices.values() if
+                            'be15beef-6186-407e-8381-0bd89c4d8df4' in d[1].service_uuids]
             for device in _all_devices:
                 local_name = device[1].local_name
                 state = list(local_name.encode('utf-8'))[0]
@@ -46,7 +47,7 @@ class FleetController:
                     _active_devices.append(device[0].address)
         else:
             _active_devices = [d[0].address for d in ble_devices.values() if
-                               d[0].name is not None and "Drive" in d[0].name]
+                               'be15beef-6186-407e-8381-0bd89c4d8df4' in d[1].service_uuids]
         return _active_devices
 
     async def auto_discover_anki_vehicles(self) -> None:


### PR DESCRIPTION
This is done by using the advertised service UUID as filter instead of filtering by the device name